### PR TITLE
Mention the short onion name for Greekleaks

### DIFF
--- a/site/en/index.html
+++ b/site/en/index.html
@@ -190,7 +190,10 @@
                     <ol>
                         <li aria-level="1">Download and install software to access the Tor network: <a target="_blank" rel="noreferrer noopener" href="https://www.torproject.org/">https://www.torproject.org</a> (Tor software guarantees user anonymity).</li>
                         <li aria-level="1">Open the Tor browser, select "connect to Tor" and wait until you are connected.</li>
-                        <li aria-level="1">Once connected, please <b>copy and paste</b> Reporters United's SecureDrop onion link address:
+                        <li aria-level="1">Once connected, please <b>copy and paste</b> one of the following "onion link" addresses to Reporters United's SecureDrop instance:
+                            <div class="code-block">
+                                <code>greekleaks.securedrop.tor.onion</code>
+                            </div>
                             <div class="code-block">
                                 <code>jatasaqcoe7lqdpcyxo7vl3e5tdvl5jgmtadfat77i25qdj6z6a4ulad.onion</code>
                             </div>

--- a/site/index.html
+++ b/site/index.html
@@ -190,7 +190,10 @@
                     <ol>
                         <li aria-level="1">Κατεβάστε και εγκαταστήστε τον φυλλομετρητή (browser) Tor από τη διεύθυνση <a href="https://www.torproject.org/" target="_blank" rel="noopener noreferrer">https://www.torproject.org</a> (Το Tor είναι ένα λογισμικό που εγγυάται την ανωνυμία του χρήστη).</li>
                         <li aria-level="1">Ανοίξτε τον Tor browser, επιλέξτε «σύνδεση στον Tor» και περιμένετε να γίνει η σύνδεση.</li>
-                        <li aria-level="1">Μόλις αυτό επιτευχθεί, <strong>αντιγράψτε – επικολλήστε (copy – paste)</strong> το λεγόμενο «onion link» με τη διεύθυνση του Reporters United στο SecureDrop:
+                        <li aria-level="1">Μόλις αυτό επιτευχθεί, <strong>αντιγράψτε – επικολλήστε (copy – paste)</strong> ένα από τα παρακάτω «onion links» με τη διεύθυνση του Reporters United στο SecureDrop:
+                            <div class="code-block">
+                                <code>greekleaks.securedrop.tor.onion</code>
+                            </div>
                             <div class="code-block">
                                 <code>jatasaqcoe7lqdpcyxo7vl3e5tdvl5jgmtadfat77i25qdj6z6a4ulad.onion</code>
                             </div>


### PR DESCRIPTION
Our Greekleaks instance now has a short onion name that our sources can use for more convenience. Mention it in our landing page, alongside the original, but longer, onion link.